### PR TITLE
Export typings in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,13 @@
   "type": "module",
   "main": "./apexsankey.min.js",
   "module": "./apexsankey.es.min.js",
-  "typings": "./index.d.ts",
+  "types": "index.d.ts",
   "exports": {
     ".": {
-      "import": "./apexsankey.es.min.js",
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./apexsankey.es.min.js"
+      },
       "require": "./apexsankey.min.js"
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "type": "module",
   "main": "./apexsankey.min.js",
   "module": "./apexsankey.es.min.js",
-  "types": "index.d.ts",
+  "types": "./index.d.ts",
   "exports": {
     ".": {
       "import": {


### PR DESCRIPTION
When importing the module using:
```
import ApexSankey from "apexsankey";
```
Typescript complain about the types not being loaded to respect the `exports` field in package.json:

![image](https://github.com/user-attachments/assets/26ed2ea6-3a3c-4246-8afa-41b151e09a44)

To solve this, according to [package.json Conditional exports](https://nodejs.org/api/packages.html#conditional-exports) we need to specify the file path for the types to the `import` condition to be loaded.
```json
{
  "exports": {
    ".": {
      "import": {
        "types": "./index.d.ts",
        "default": "./apexsankey.es.min.js"
      }
    }
  }
}
```